### PR TITLE
Skip anything that's not a regular file in the config dir

### DIFF
--- a/config.go
+++ b/config.go
@@ -283,7 +283,7 @@ func (proxy *Inkfish) LoadConfigFromDirectory(configDir string) error {
 		return errors.Wrap(err, msg)
 	}
 	for _, fi := range files {
-		if fi.IsDir() {
+		if !fi.Mode().IsRegular() {
 			continue
 		}
 		fullpath := filepath.Join(configDir, fi.Name())


### PR DESCRIPTION
This fixes an error using a kube configmap as the configuration directory:

```
2020/01/21 06:21:02 config error: failed read config file: /cm/..data: read /cm/..data: is a directory
```