### PR TITLE
Try harder to make symbolic links work.

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -238,3 +238,12 @@ func TestLoadConfig(t *testing.T) {
 
 	assert.Equal(t, 2, len(proxy.Acls))
 }
+
+func TestLoadConfigWithSymlink(t *testing.T) {
+	proxy := NewInkfish(NewCertSigner(&StubCA))
+	err := proxy.LoadConfigFromDirectory("testdata/symlink_test_config")
+	assert.NotNil(t, proxy.Acls)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 2, len(proxy.Acls))
+}

--- a/testdata/symlink_test_config/anon.conf
+++ b/testdata/symlink_test_config/anon.conf
@@ -1,0 +1,1 @@
+../unit_test_config/anon.conf

--- a/testdata/symlink_test_config/circular.thing
+++ b/testdata/symlink_test_config/circular.thing
@@ -1,0 +1,1 @@
+circular.thing

--- a/testdata/symlink_test_config/dockerhub.conf
+++ b/testdata/symlink_test_config/dockerhub.conf
@@ -1,0 +1,1 @@
+../unit_test_config/dockerhub.conf

--- a/testdata/symlink_test_config/does.not.exist
+++ b/testdata/symlink_test_config/does.not.exist
@@ -1,0 +1,1 @@
+/does.not.exist


### PR DESCRIPTION
Second attempt.

A configmap mounted in a pod has symlinks for *all* the keys in the config map, plus a few random extra symlinks to directories.

Since we need to resolve symlinks to make this work, now we need to account for circular links, and possibilities like e.g. links to links to links inside config directory itself, e.g:

```
/config
/config/aaa.conf -> bbb.conf
/config/bbb.conf -> ccc.conf
/config/ccc.conf   # Regular file
```

The above would cause ccc.conf to be loaded 3 times. This would be inefficient but not harmful.