### PR TITLE
Add metrics prometheus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ go: 1.x
 env:
   - GO111MODULE=on
 script:
-  - DOCKER_CONTENT_TRUST=1 docker build . -t bsycorp/inkfish:${TRAVIS_BRANCH}
-  - DOCKER_CONTENT_TRUST=1 docker build . -f Dockerfile-slim -t bsycorp/inkfish:${TRAVIS_BRANCH}-slim
-  - docker create --name built bsycorp/inkfish:${TRAVIS_BRANCH}
+  - DOCKER_CONTENT_TRUST=1 docker build . -t bsycorp/inkfish:${TRAVIS_BRANCH//\//-}
+  - DOCKER_CONTENT_TRUST=1 docker build . -f Dockerfile-slim -t bsycorp/inkfish:${TRAVIS_BRANCH//\//-}-slim
+  - docker create --name built bsycorp/inkfish:${TRAVIS_BRANCH//\//-}
   - docker cp built:/app/inkfish inkfish-linux-amd64
 deploy:
   - provider: script

--- a/cmd/inkfish/main.go
+++ b/cmd/inkfish/main.go
@@ -6,6 +6,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/bsycorp/inkfish"
 	"github.com/syntaqx/go-metrics-datadog"
+	prometheusmetrics "github.com/deathowl/go-metrics-prometheus"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"log"
 	"net/http"
 	"os"
@@ -100,6 +103,10 @@ func main() {
 		//reporter.Client.Tags = append(reporter.Client.Tags, "us-east-1a")
 		go reporter.Flush()
 		log.Println("metrics to datadogstatsd at: ", dogStatsdAddr)
+	} else if strings.HasPrefix(*metrics, "prometheus") {
+		prometheusClient := prometheusmetrics.NewPrometheusProvider(proxy.Metrics.Registry, "inkfish", "proxy", prometheus.DefaultRegisterer, 1*time.Second)
+		go prometheusClient.UpdatePrometheusMetrics()
+		proxy.PromHandler = promhttp.Handler()
 	} else {
 		log.Fatal("unknown metrics provider: ", *metrics)
 	}

--- a/inkfish.go
+++ b/inkfish.go
@@ -65,6 +65,9 @@ type Inkfish struct {
 
 	// Shared HTTP transport
 	Transport *http.Transport
+
+	//Prometheus Handler
+	PromHandler http.Handler
 }
 
 func NewInkfish(signer *CertSigner) *Inkfish {
@@ -335,6 +338,8 @@ func (proxy *Inkfish) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// Health check
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte("ok"))
+	} else if req.URL.Scheme == "" && req.URL.Path == "/metrics" && proxy.PromHandler != nil {
+		proxy.PromHandler.ServeHTTP(w, req)
 	} else if req.Method == "CONNECT" {
 		// Client requested a CONNECT tunnel from the proxy
 		filterAction := proxy.filterConnect(w, req)


### PR DESCRIPTION
Add route to inkfish proxy for collecting prometheus metrics, so that incoming request on '/metrics' will be forwarded onto prometheus http handle to dump the metrics.