### PR TITLE
Add scheduled task of reloading proxy Acls from dynamoDB table.

### DIFF
--- a/cmd/inkfish/main.go
+++ b/cmd/inkfish/main.go
@@ -65,7 +65,10 @@ func main() {
 		go func() {
 			for {
 				log.Println("Reload proxy ACLs from DynamoDB")
-				proxy.LoadConfigFromDyanmoDB(sess, *ddbConfig)
+				err := proxy.LoadConfigFromDynamoDB(sess, *ddbConfig)
+				if err != nil {
+					log.Println("error reloading config: ", err)
+				}
 				time.Sleep(60 * time.Second)
 			}
 		}()
@@ -73,7 +76,10 @@ func main() {
 		go func() {
 			for {
 				log.Println("Reload proxy ACLs from local config directory")
-				proxy.LoadConfigFromDirectory(*configDir, "reload")
+				err := proxy.LoadConfigFromDirectory(*configDir, "reload")
+				if err != nil {
+					log.Println("error reloading config: ", err)
+				}
 				time.Sleep(60 * time.Second)
 			}
 		}()

--- a/config_test.go
+++ b/config_test.go
@@ -249,36 +249,18 @@ func TestLoadConfigWithSymlink(t *testing.T) {
 }
 
 func TestLoadConfigFromLocalDirFails(t *testing.T) {
-    proxy := NewInkfish(NewCertSigner(&StubCA))
-    err := proxy.LoadConfig("dir-does-not-exist/nofile", "")
-    assert.Nil(t, proxy.Acls)
-    assert.NotNil(t, err)
-
-	assert.Equal(t, 0, len(proxy.Acls))
-}
-
-func TestLoadConfigFromDdbFails(t *testing.T) {
-    proxy := NewInkfish(NewCertSigner(&StubCA))
-    err := proxy.LoadConfig(".", "ddb-does-not-exist")
-    assert.Nil(t, proxy.Acls)
-    assert.NotNil(t, err)
-
-	assert.Equal(t, 0, len(proxy.Acls))
-}
-
-func TestLoadConfigMultipleFailures(t *testing.T) {
-    proxy := NewInkfish(NewCertSigner(&StubCA))
-    err := proxy.LoadConfig("dir-does-not-exist/nofile", "ddb-does-not-exist")
-    assert.Nil(t, proxy.Acls)
-    assert.NotNil(t, err)
+	proxy := NewInkfish(NewCertSigner(&StubCA))
+	err := proxy.LoadConfig("dir-does-not-exist/nofile", "")
+	assert.Nil(t, proxy.Acls)
+	assert.NotNil(t, err)
 
 	assert.Equal(t, 0, len(proxy.Acls))
 }
 
 func TestLoadEmptyConfig(t *testing.T) {
-    proxy := NewInkfish(NewCertSigner(&StubCA))
-    err := proxy.LoadConfig(".", "")
-    assert.Nil(t, err)
+	proxy := NewInkfish(NewCertSigner(&StubCA))
+	err := proxy.LoadConfig(".", "")
+	assert.Nil(t, err)
 
 	assert.Equal(t, 0, len(proxy.Acls))
 }

--- a/config_test.go
+++ b/config_test.go
@@ -230,18 +230,9 @@ func TestAclConfigWithMissingPortInBypass(t *testing.T) {
 	assert.Equal(t, "missing port in bypass at line: 5", err.Error())
 }
 
-func TestLoadConfig(t *testing.T) {
+func TestLoadConfigFromLocalDirOnly(t *testing.T) {
 	proxy := NewInkfish(NewCertSigner(&StubCA))
-	err := proxy.LoadConfigFromDirectory("testdata/unit_test_config")
-	assert.NotNil(t, proxy.Acls)
-	assert.Nil(t, err)
-
-	assert.Equal(t, 2, len(proxy.Acls))
-}
-
-func TestReloadConfigFromDirectory(t *testing.T) {
-	proxy := NewInkfish(NewCertSigner(&StubCA))
-	err := proxy.LoadConfigFromDirectory("testdata/unit_test_config", "reload")
+	err := proxy.LoadConfig("testdata/unit_test_config", "")
 	assert.NotNil(t, proxy.Acls)
 	assert.Nil(t, err)
 
@@ -250,9 +241,44 @@ func TestReloadConfigFromDirectory(t *testing.T) {
 
 func TestLoadConfigWithSymlink(t *testing.T) {
 	proxy := NewInkfish(NewCertSigner(&StubCA))
-	err := proxy.LoadConfigFromDirectory("testdata/symlink_test_config")
+	err := proxy.LoadConfig("testdata/symlink_test_config", "")
 	assert.NotNil(t, proxy.Acls)
 	assert.Nil(t, err)
 
 	assert.Equal(t, 2, len(proxy.Acls))
+}
+
+func TestLoadConfigFromLocalDirFails(t *testing.T) {
+    proxy := NewInkfish(NewCertSigner(&StubCA))
+    err := proxy.LoadConfig("dir-does-not-exist/nofile", "")
+    assert.Nil(t, proxy.Acls)
+    assert.NotNil(t, err)
+
+	assert.Equal(t, 0, len(proxy.Acls))
+}
+
+func TestLoadConfigFromDdbFails(t *testing.T) {
+    proxy := NewInkfish(NewCertSigner(&StubCA))
+    err := proxy.LoadConfig(".", "ddb-does-not-exist")
+    assert.Nil(t, proxy.Acls)
+    assert.NotNil(t, err)
+
+	assert.Equal(t, 0, len(proxy.Acls))
+}
+
+func TestLoadConfigMultipleFailures(t *testing.T) {
+    proxy := NewInkfish(NewCertSigner(&StubCA))
+    err := proxy.LoadConfig("dir-does-not-exist/nofile", "ddb-does-not-exist")
+    assert.Nil(t, proxy.Acls)
+    assert.NotNil(t, err)
+
+	assert.Equal(t, 0, len(proxy.Acls))
+}
+
+func TestLoadEmptyConfig(t *testing.T) {
+    proxy := NewInkfish(NewCertSigner(&StubCA))
+    err := proxy.LoadConfig(".", "")
+    assert.Nil(t, err)
+
+	assert.Equal(t, 0, len(proxy.Acls))
 }

--- a/config_test.go
+++ b/config_test.go
@@ -239,6 +239,15 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, 2, len(proxy.Acls))
 }
 
+func TestReloadConfigFromDirectory(t *testing.T) {
+	proxy := NewInkfish(NewCertSigner(&StubCA))
+	err := proxy.LoadConfigFromDirectory("testdata/unit_test_config", "reload")
+	assert.NotNil(t, proxy.Acls)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 2, len(proxy.Acls))
+}
+
 func TestLoadConfigWithSymlink(t *testing.T) {
 	proxy := NewInkfish(NewCertSigner(&StubCA))
 	err := proxy.LoadConfigFromDirectory("testdata/symlink_test_config")

--- a/go.sum
+++ b/go.sum
@@ -50,7 +50,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -77,7 +76,6 @@ github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
@@ -99,6 +97,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
**Add feature of loading proxy rules from DynamoDB:**
1. Add a new flag `ddbconfig` for receiving name of DynamoDB table storing proxy configurations. If the flag is set, a background task scheduled every minute will reload proxy configurations from the DynamoDB table by doing a full table scan. If the flag is not set, then proxy configurations will be reloaded from local configuration directory every minute.
2. Initial proxy configurations are still loaded from local configuration directory during proxy bootstrapping process.`LoadConfigFromDirectory` now takes an extra optional argument flagging if the process is an initial configuration loading or reloading. If reloading fails, initial configurations remain unchanged.
3. DynamoDB table and configuration items will be created in infrastructure codebase, which is not within the scope of inkfish. The table will contain two columns: `ConfigName` (key) and `ConfigBody` (base64 encoded string of proxy configuration).

**Integration testing**
1. Initial proxy configuration loading succeeds.
2. Minutely proxy configuration reloading succeeds.
3. Changes of proxy configuration are picked up correctly after configuration reloading.
_Note: bsycorp/inkfish@sha256:29d9ca858e4ee196c6f297569362239f3ddffa484e232cebf71044b0dc40acd4 is built from this branch and tested._

**Options LocalDir + DDB**
1. Option 1: [Commit 8f7e1ab](https://github.com/bsycorp/inkfish/pull/25/commits/8f7e1ab9aa1f96bc0fdf1de3c19235df3c09b119)
-- DDB tables of proxy rules at apps level are created from TF codes in apps repos, which is independent from infra codes.
-- Inkfish startup flag `-ddb-config` takes a DDB table name regex (e.g. -ddb-config ${var.env_label}[^0-9]+proxy-rules) to discover all matching DDB tables for the current environment.
-- For each proxy config reloading process, the list of all DDB tables having table name matching the name regex will be scanned.