### PR TITLE
Fix Dockerhub login and Release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERUSER }}
+        password: ${{ secrets.DOCKERPASS }}
     - name: Build and Publish Image
       run: |
-        echo ${{ secrets.DOCKERPASS }} | docker login -u ${{ secrets.DOCKERUSER }} --password-stdin
-        DOCKER_CONTENT_TRUST=1 docker build . -t bsycorp/inkfish:1.0.${{ github.run_number }}
-        DOCKER_CONTENT_TRUST=1 docker build . -f Dockerfile-slim -t bsycorp/inkfish:1.0.${{ github.run_number }}-slim
-        docker create --name built bsycorp/inkfish:1.0.${{ github.run_number }}
+        DOCKER_CONTENT_TRUST=1 docker build . -t bsycorp/inkfish:${GITHUB_REF#refs/*/}
+        DOCKER_CONTENT_TRUST=1 docker build . -f Dockerfile-slim -t bsycorp/inkfish:${GITHUB_REF#refs/*/}-slim
+        docker create --name built bsycorp/inkfish:${GITHUB_REF#refs/*/}
         docker cp built:/app/inkfish inkfish-linux-amd64
-        docker tag  bsycorp/inkfish:1.0.${{ github.run_number }} bsycorp/inkfish:latest
-        docker tag  bsycorp/inkfish:1.0.${{ github.run_number }}-slim bsycorp/inkfish:latest-slim
-        docker push bsycorp/inkfish
+        docker tag bsycorp/inkfish:${GITHUB_REF#refs/*/} bsycorp/inkfish:latest
+        docker tag bsycorp/inkfish:${GITHUB_REF#refs/*/}-slim bsycorp/inkfish:latest-slim
+        docker push bsycorp/inkfish:${GITHUB_REF#refs/*/} bsycorp/inkfish:${GITHUB_REF#refs/*/}-slim
+        docker push bsycorp/inkfish:latest bsycorp/inkfish:latest-slim
     - name: Upload Release Asset
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
- Reference docker username and password from GitHub account secrets for login.
- Use commit tag as the image tag, same image tagging logic as in travis build.